### PR TITLE
Update SnippetsTests

### DIFF
--- a/src/test/java/snippets/SnippetsTests.java
+++ b/src/test/java/snippets/SnippetsTests.java
@@ -328,7 +328,7 @@ public class SnippetsTests {
         obj.put("c", 3);
 
         Map<String, Integer> picked = Snippets.pick(obj, new String[]{"a", "c"});
-        assertThat(picked).containsExactly(new SimpleEntry<>("a", 1), new SimpleEntry<>("c", 3));
+        assertThat(picked).containsOnly(new SimpleEntry<>("a", 1), new SimpleEntry<>("c", 3));
     }
 
     @Test


### PR DESCRIPTION
### What this pull request does 
This pull request fixes the flaky test `SnippetsTests.pick_should_pick_key_pairs_corresponding_to_keys`. The test passes sometimes and fails other times because the `Snippets.pick` method does not preserve the order of elements in a list, while the test assumes a specific order. 

### Why the test is flaky 
The `containsExactly` method assumes that the map `groups` will have a specific order, but the`Snippets.pick` method can return a map with elements in any order. 

### How the test was fixed 
The test can be fixed by replacing `containsExactly` with `containsOnly`, which does not assume a specific order. 

### Output from testing 
Running `SnippetsTests.pick_should_pick_key_pairs_corresponding_to_keys` with `NonDex` shows the test failing: 
`mvn -e -pl . edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=snippets.SnippetsTests#pick_should_pick_key_pairs_corresponding_to_keys` 

[ERROR] pick_should_pick_key_pairs_corresponding_to_keys(snippets.SnippetsTests)  Time elapsed: 0.039 s  <<< FAILURE! java.lang.AssertionError: Actual and expected have the same elements but not in the same order, at index 0 actual element was: <MapEntry[key="c", value=3]> whereas expected element was: <a=1>